### PR TITLE
fix: fix some little style bugs

### DIFF
--- a/src/app/components/Navigation.tsx
+++ b/src/app/components/Navigation.tsx
@@ -20,7 +20,7 @@ export default function Navigation(): ReactNode {
   }
 
   return (
-    <nav className="w-screen">
+    <nav>
       <div
         className={`flex flex-col bg-spotify-light-dark max-md:mx-4 max-md:mt-4 mx-32 mt-4 p-2 rounded-full max-md:rounded-xl
          `}

--- a/src/app/components/ui/type-writer-effect.tsx
+++ b/src/app/components/ui/type-writer-effect.tsx
@@ -72,7 +72,7 @@ export const TypewriterEffect = ({
   return (
     <div
       className={cn(
-        "text-base sm:text-xl md:text-3xl lg:text-5xl font-bold text-center",
+        "text-base sm:text-xl md:text-3xl lg:text-5xl font-bold text-center flex items-end",
         className
       )}
     >
@@ -90,7 +90,7 @@ export const TypewriterEffect = ({
           repeatType: "reverse",
         }}
         className={cn(
-          "inline-block rounded-sm w-[4px] h-4 md:h-6 lg:h-10 bg-blue-500",
+          "inline-block rounded-sm w-[4px] h-4 md:h-6 lg:h-10 bg-blue-500 mb-2",
           cursorClassName
         )}
       ></motion.span>


### PR DESCRIPTION
### changes
- changed the name typewriter effect so the blue bar (cursor? idk what its called) is on the same line as the name text
- removed w-screen from navbar so on windows it doesn't overflow and create a horizontal scrollbar (mac doesnt do this its quite odd)

cheers

![123943751_p0](https://github.com/user-attachments/assets/d541442c-a323-4833-b81c-16ffa00de7fd)
