### PR TITLE
Add Dockerfile and Docker compose, now able to run without Node

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+# Node/Next build artifacts
+node_modules
+.next
+out
+
+# VCS & local files
+.git
+.gitignore
+Dockerfile*
+docker-compose*.yml
+README.md
+
+# OS/editor
+.DS_Store
+*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+# ---------- Base deps (install lockfile deps exactly) ----------
+FROM node:18-alpine AS deps
+WORKDIR /app
+RUN apk add --no-cache libc6-compat
+COPY package.json package-lock.json* pnpm-lock.yaml* yarn.lock* ./
+# Use the detected lockfile
+RUN if [ -f pnpm-lock.yaml ]; then \
+        corepack enable && corepack prepare pnpm@latest --activate && pnpm i --frozen-lockfile; \
+    elif [ -f yarn.lock ]; then yarn --frozen-lockfile; \
+    else npm ci; fi
+
+# ---------- Builder (Next.js standalone build) ----------
+FROM node:18-alpine AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+# Ensure: next.config.mjs has `output: "standalone"`
+ENV NODE_ENV=production
+RUN npm run build
+
+# ---------- Runner (lean runtime image) ----------
+FROM node:18-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+ENV PORT=3000
+# Optionally set this if you rely on Next telemetry/analytics defaults
+# ENV NEXT_TELEMETRY_DISABLED=1
+
+# Copy only what's needed to run
+COPY --from=builder /app/.next/standalone ./
+COPY --from=builder /app/public ./public
+COPY --from=builder /app/.next/static ./.next/static
+
+# (Optional) drop privileges
+# RUN addgroup -g 1001 -S nextjs && adduser -S nextjs -u 1001
+# USER nextjs
+
+EXPOSE 3000
+
+# Next standalone outputs a server.js entrypoint at repo root inside /app
+CMD ["node", "server.js"]

--- a/README.md
+++ b/README.md
@@ -4,9 +4,7 @@
 
 <img src="public/portfolio_highres.png" width="700"  alt="Portfolio Preview">
 
----
-
-A modern, responsive portfolio website featuring a [Spotify](spotify.com)-inspired design. Hosted on [Vercel](https://vercel.com)
+A modern, responsive portfolio website featuring a design, inspired by Spotify.
 
 This website is powered by [Next.js 15](https://nextjs.org/), [Tailwind CSS](https://tailwindcss.com/), and [Aceternity UI](https://ui.aceternity.com/). To develop, run:
 
@@ -16,6 +14,19 @@ $ npm install
 $ npm run dev
 ```
 
+To run with Docker:
+
+```bash
+$ docker build -t luan/portfolio .
+$ docker run --rm -p 3000:3000 luan/portfolio
+```
+
+With hot reload:
+
+```bash
+$ docker compose -f docker-compose.dev.yml up
+```
+
 ---
 
-❤️ by [Luan Nguyen](https://www.linkedin.com/in/luanthiennguyen/)
+Made with ❤️ by [Luan Nguyen](https://www.linkedin.com/in/luaanng/)

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,14 @@
+version: "3.9"
+services:
+  web:
+    image: node:18-alpine
+    working_dir: /app
+    command: sh -c "npm i && npm run dev"
+    ports:
+      - "3000:3000"
+    volumes:
+      - .:/app
+      - /app/node_modules
+    environment:
+      - NODE_ENV=development
+      - PORT=3000

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  output: "standalone",
   images: {
     remotePatterns: [
       {


### PR DESCRIPTION
 - Added `output: "standalone"` so the build generates a lean, self-contained bundle at `.next/standalone`.
 - Added multi-stage Dockerfile: build dependencies, compiles NextJS app, then copies only the runtime into a slim `node:18-alpine` image
 - Added `.dockerignore`
 - Production: `docker build` + `docker run`
 - Development: `docker-compose.dev.yml` for hot-reload

